### PR TITLE
Points to production. Breaks precommit so i can commit

### DIFF
--- a/app/common/constants.js
+++ b/app/common/constants.js
@@ -3,7 +3,7 @@ export const RAVEN_DSN = 'https://0e8d8bd5cc8142dda1cedeaabc91b1d2@sentry.io/286
 export const IS_DEV_ENV = process.env.NODE_ENV === 'development';
 export const IS_PROD_ENV = process.env.NODE_ENV === 'production';
 const DEV_DOMAIN = 'https://staging.kaniwani.com';
-const PROD_DOMAIN = 'https://staging.kaniwani.com'; // FIXME: what's the final api server?
+const PROD_DOMAIN = 'https://kaniwani.com'; 
 const BASE_URL = IS_DEV_ENV ? DEV_DOMAIN : PROD_DOMAIN;
 
 export const API_BASE = `${BASE_URL}/api/v1/`;


### PR DESCRIPTION
By default, I couldn't commit, due to this error. Do you have non-project-package which provides your precommit hooks? In line 2 of .git/hooks/precommit it referenced ./node_modules/pre-commit which did not exist. Anyhow, just fixed up the prod URL. 