### PR TITLE
Remove forecast offset, show current reviews in chart

### DIFF
--- a/app/common/utils/formatUpcomingReviews.js
+++ b/app/common/utils/formatUpcomingReviews.js
@@ -5,7 +5,7 @@ const formatUpcomingReviews = (data = []) => {
   let extraDays = 0;
   const getFutureDayName = (daysAhead = 0) => format(addDays(new Date(), daysAhead), 'dddd');
   const genDay = (hour) => (hour === '12am' ? getFutureDayName((extraDays += 1)) : '');
-  const genHour = (index) => `${format(addHours(new Date(), index + 1), 'ha')}`;
+  const genHour = (index) => `${format(addHours(new Date(), index), 'ha')}`;
 
   return data.reduce((list, value, index) => {
     const hour = genHour(index);

--- a/app/features/dashboard/UpcomingReviewsChart/index.js
+++ b/app/features/dashboard/UpcomingReviewsChart/index.js
@@ -5,7 +5,7 @@ import ReactInterval from 'react-interval';
 import { ResponsiveContainer, BarChart, Brush, Bar, XAxis, YAxis, CartesianGrid } from 'recharts';
 import { startOfHour, setHours, isBefore } from 'date-fns';
 import { get } from 'lodash';
-import { selectOnVacation, selectUpcomingReviews } from 'features/user/selectors';
+import { selectOnVacation, selectReviewsCount, selectUpcomingReviews } from 'features/user/selectors';
 
 import user from 'features/user/actions';
 
@@ -24,14 +24,17 @@ UpcomingReviewsChart.propTypes = {
       value: PropTypes.number.isRequired,
     }),
   ).isRequired,
+  reviewsCount: PropTypes.number.isRequired,
 };
 
-export function UpcomingReviewsChart({ data }) {
+export function UpcomingReviewsChart({ data, reviewsCount }) {
+  const aggregateData = data;
+  aggregateData[0] = { ...aggregateData[0], value: reviewsCount };
   return (
     <Element flexRow flexCenter style={{ fontSize: '.75rem' }}>
       <ResponsiveContainer width="100%" minWidth={320} height={300} debounce={100}>
         <BarChart
-          data={data}
+          data={aggregateData}
           barCategoryGap={2}
           maxBarSize={40}
           margin={{ top: 5, right: 35, left: 20 }}
@@ -83,7 +86,7 @@ UpcomingReviewsChartContainer.propTypes = {
   loadUser: PropTypes.func.isRequired,
 };
 
-function UpcomingReviewsChartContainer({ data, loadUser, isOnVacation }) {
+function UpcomingReviewsChartContainer({ data, loadUser, isOnVacation, reviewsCount }) {
   const updateCounts = React.useCallback(() => {
     const hour = get(data, [0, 'hour'], null);
 
@@ -108,13 +111,14 @@ function UpcomingReviewsChartContainer({ data, loadUser, isOnVacation }) {
   ) : (
     <>
       <ReactInterval enabled timeout={10000} callback={updateCounts} />
-      <UpcomingReviewsChart data={data} />
+      <UpcomingReviewsChart data={data} reviewsCount={reviewsCount} />
     </>
   );
 }
 
 const mapStateToProps = (state) => ({
   data: selectUpcomingReviews(state),
+  reviewsCount: selectReviewsCount(state),
   isOnVacation: selectOnVacation(state),
 });
 

--- a/app/features/dashboard/UpcomingReviewsChart/index.js
+++ b/app/features/dashboard/UpcomingReviewsChart/index.js
@@ -5,7 +5,11 @@ import ReactInterval from 'react-interval';
 import { ResponsiveContainer, BarChart, Brush, Bar, XAxis, YAxis, CartesianGrid } from 'recharts';
 import { startOfHour, setHours, isBefore } from 'date-fns';
 import { get } from 'lodash';
-import { selectOnVacation, selectReviewsCount, selectUpcomingReviews } from 'features/user/selectors';
+import {
+  selectOnVacation,
+  selectReviewsCount,
+  selectUpcomingReviews,
+} from 'features/user/selectors';
 
 import user from 'features/user/actions';
 
@@ -29,6 +33,7 @@ UpcomingReviewsChart.propTypes = {
 
 export function UpcomingReviewsChart({ data, reviewsCount }) {
   const aggregateData = data;
+  // Populate current hour with currently available review count
   aggregateData[0] = { ...aggregateData[0], value: reviewsCount };
   return (
     <Element flexRow flexCenter style={{ fontSize: '.75rem' }}>
@@ -84,6 +89,7 @@ UpcomingReviewsChartContainer.propTypes = {
   data: PropTypes.array.isRequired,
   isOnVacation: PropTypes.bool.isRequired,
   loadUser: PropTypes.func.isRequired,
+  reviewsCount: PropTypes.number.isRequired,
 };
 
 function UpcomingReviewsChartContainer({ data, loadUser, isOnVacation, reviewsCount }) {


### PR DESCRIPTION
## KaniWani

This PR makes 2 changes:
* Remove a "bug" in the displayed time of pending reviews (currently, any review with review date at hour H is displayed at hour H+1), shifting all review times to be listed at the start of their hour
* Populates the current hour with the user's currrently available reviews
  * e.g. if it's currently 15:20 and the user has 5 reviews, the "3pm" column will be displayed in the chart with 5 reviews

[Issue Ticket](https://github.com/Kaniwani/kw-frontend/issues/104)

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/Kaniwani/kw-frontend/blob/master/.github/CONTRIBUTING.md)
- [x] double-check your branch is based on `dev` and targets `dev`
- [ ] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Internal code generators and templates are updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues


**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [MIT License](https://github.com/Kaniwani/kw-frontend/blob/master/LICENSE.md).
