### PR TITLE
Fix queue loading of final review

### DIFF
--- a/app/features/quiz/QuizSession/logic.js
+++ b/app/features/quiz/QuizSession/logic.js
@@ -29,13 +29,12 @@ export const queueLoadLogic = createLogic({
       const queueCount = selectQueueCount(getState());
       const remainingCount = selectSessionRemainingCount(getState());
       const wrapUp = selectWrapUp(getState());
-      const unqueuedSessionItems = remainingCount - queueCount;
       // eslint-disable-next-line no-nested-ternary
       const limit = !queueCount
         ? INITIAL_QUEUE_LIMIT
         : wrapUp.active
           ? wrapUp.count - queueCount
-          : Math.min(unqueuedSessionItems, SUBSEQUENT_QUEUE_LIMIT);
+          : Math.min(remainingCount, SUBSEQUENT_QUEUE_LIMIT);
 
       allow({ ...action, payload: { category, limit, currentId } });
     } else {

--- a/app/features/quiz/QuizSession/selectors.js
+++ b/app/features/quiz/QuizSession/selectors.js
@@ -2,23 +2,22 @@ import { createSelector } from 'reselect';
 
 import calculatePercentage from 'common/utils/calculatePercentage';
 
-import { SESSION_CATEGORIES, MINIMUM_QUEUE_COUNT } from './constants';
-
 import { getState } from 'common/selectors';
 import { selectLessonsCount, selectReviewsCount } from 'features/user/selectors';
 import { selectPrimaryVocabId } from 'features/reviews/selectors';
 import { selectVocabById } from 'features/vocab/selectors';
+import { SESSION_CATEGORIES, MINIMUM_QUEUE_COUNT } from './constants';
 
 export const UI_DOMAIN = 'quizSession';
 export const selectQuizDomain = getState(UI_DOMAIN);
 export const selectCategory = getState([UI_DOMAIN, 'category'], '');
 export const selectIsLessonQuiz = createSelector(
   selectCategory,
-  (category) => category === SESSION_CATEGORIES.LESSONS
+  (category) => category === SESSION_CATEGORIES.LESSONS,
 );
 export const selectIsReviewQuiz = createSelector(
   selectCategory,
-  (category) => category === SESSION_CATEGORIES.REVIEWS
+  (category) => category === SESSION_CATEGORIES.REVIEWS,
 );
 
 export const selectQueue = createSelector(selectQuizDomain, getState('queue', []));
@@ -33,14 +32,14 @@ export const selectIncorrectCount = createSelector(selectIncorrectIds, getState(
 export const selectCompleteCount = createSelector(selectCompleteIds, getState('length', 0));
 export const selectSynonymModalOpen = createSelector(
   selectQuizDomain,
-  getState('synonymModalOpen')
+  getState('synonymModalOpen'),
 );
 export const selectCurrentId = createSelector(selectCurrent, getState('id'));
 export const selectCurrentStreak = createSelector(selectCurrent, getState('streak'));
 
 export const selectPrimaryVocabFromCurrent = createSelector(
   [selectCurrentId, (state) => state],
-  (id, state) => selectVocabById(state, { id: selectPrimaryVocabId(state, { id }) })
+  (id, state) => selectVocabById(state, { id: selectPrimaryVocabId(state, { id }) }),
 );
 
 export const selectSessionCount = createSelector(
@@ -49,22 +48,22 @@ export const selectSessionCount = createSelector(
     if (isLessonQuiz) return lessons;
     if (isReviewsQuiz) return reviews;
     return 0;
-  }
+  },
 );
 
 export const selectSessionRemainingCount = createSelector(
   [selectSessionCount, selectCompleteCount],
-  (sessionCount, completeCount) => sessionCount - completeCount
+  (sessionCount, completeCount) => sessionCount - completeCount,
 );
 
 export const selectCurrentPreviouslyIncorrect = createSelector(
   [selectCurrentId, selectIncorrectIds],
-  (currentId, incorrectIds) => incorrectIds.includes(currentId)
+  (currentId, incorrectIds) => incorrectIds.includes(currentId),
 );
 
 export const selectPercentComplete = createSelector(
   [selectCompleteCount, selectSessionRemainingCount],
-  (complete, remaining) => calculatePercentage(complete, complete + remaining)
+  (complete, remaining) => calculatePercentage(complete, complete + remaining),
 );
 
 export const selectPercentCorrect = createSelector(
@@ -73,7 +72,7 @@ export const selectPercentCorrect = createSelector(
     const total = correct + incorrect;
     const pristine = total < 1;
     return pristine ? 100 : calculatePercentage(correct, total);
-  }
+  },
 );
 
 export const selectQueueNeeded = createSelector(
@@ -84,12 +83,15 @@ export const selectQueueNeeded = createSelector(
     const moreQueueExists = remaining - queueCount >= 1;
     const queueNeeded = (needMoreWrapUp || needMoreMinimum) && moreQueueExists;
     return queueNeeded;
-  }
+  },
 );
 
 export const selectIsFinalQuestion = createSelector(
-  [selectQueue, selectCurrentId, selectWrapUp],
-  (queue, currentId) => queue.length === 1 && currentId === queue[0]
+  [selectQueue, selectSessionRemainingCount, selectCurrentId],
+  (queue, remainingCount, currentId) => {
+    console.log([queue, remainingCount, currentId]);
+    return remainingCount === 1 && currentId === queue[0];
+  },
 );
 
 export default selectQuizDomain;

--- a/app/features/quiz/QuizSession/selectors.js
+++ b/app/features/quiz/QuizSession/selectors.js
@@ -88,7 +88,11 @@ export const selectQueueNeeded = createSelector(
 
 export const selectIsFinalQuestion = createSelector(
   [selectSessionRemainingCount, selectWrapUp, selectQueue, selectCurrentId],
-  (remainingCount, wrapUp, queue, currentId) => (remainingCount === 1 || wrapUp.count === 0) && queue.length > 0 && currentId === queue[0],
+  (remainingCount, wrapUp, queue, currentId) => {
+    const isLastInQueue = queue.length > 0 && currentId === queue[0];
+    const shouldWrapUp = wrapUp.active && wrapUp.count === 0;
+    return (remainingCount === 1 || shouldWrapUp) && isLastInQueue;
+  },
 );
 
 export default selectQuizDomain;

--- a/app/features/quiz/QuizSession/selectors.js
+++ b/app/features/quiz/QuizSession/selectors.js
@@ -87,11 +87,8 @@ export const selectQueueNeeded = createSelector(
 );
 
 export const selectIsFinalQuestion = createSelector(
-  [selectQueue, selectSessionRemainingCount, selectCurrentId],
-  (queue, remainingCount, currentId) => {
-    console.log([queue, remainingCount, currentId]);
-    return remainingCount === 1 && currentId === queue[0];
-  },
+  [selectSessionRemainingCount, selectWrapUp, selectQueue, selectCurrentId],
+  (remainingCount, wrapUp, queue, currentId) => (remainingCount === 1 || wrapUp.count === 0) && queue.length > 0 && currentId === queue[0],
 );
 
 export default selectQuizDomain;


### PR DESCRIPTION
## Overview
This PR addresses a bug that happens intermittently in QuizSessions, where the final review in the session is not completed when the session is ended and the user is taken to the overview screen. The root cause stems from the fact that:
1. The `selectIsFinalQuestion` selector in QuizSession/selectors.js does not check the remaining count from the session, just the queue size
2. The `queueLoadLogic` middleware loaded new reviews as if the number loaded were all added to the queue, when the actual behavior is that the number loaded dictates the queue size. This caused discrepancies between the remaining review count and the queue size loaded, in cases where the user was nearing the end of the session. 

## Fixes
1. The first issue was fixed by changing the check for `isFinalQuestion` to compare the "completed" count with the "reviewsCount" (or checking that the wrapUp count is 0) rather than just checking that the queue is (almost) empty and that the current review is the last one in the queue. This better mirrors the logic from `selectSessionRemainingCount`, which informs how many reviews are loaded into the queue
2. The second issue was fixed by setting the query limit for queue sessions, **in the case where the remaining reviews count was within the queue limit size**, to the remainingCount instead of the difference between the current queue and the remaining count. This is because the queue is set to the length of the queried reviews, rather than the current queued reviews + the queried reviews. The bug was cause primarily by this discrepancy, because the following might happen:
* User has 51 reviews
* Initial queue loads 50 of them
* When determining whether to load the remaining reviews (once queue size < 3) the load logic would attempt to load with a limit of `remainingCount - queueCount`, which in this case would proceed as:


| Remaining reviews  | Queued Reviews |  Query limit  | Note  |
| --- | --- | --- | --- |
| 4 | 3 | (not queried) |Above MINIMUM_QUEUE_COUNT | 
| 3 | 2 | 3 - 2 = 1   |  This is one of the reviews already in the queue |
| 2 | 1 | 1 |  Loaded review already in queue. Last item in queue is current review, so `isFinalQuestion` is true |
| 1 | 0 | 1 | New review loaded, but `isFinalQuestion` already triggered summary screen |

So, either of the above fixes avoids this scenario

## To verify
The scenario above with 51 reviews is one example of the right scenario to trigger the bug, but it can be reproduced by changing the INITIAL_QUEUE_LIMIT to however many reviews you have -1. In general, the number n to reproduce this scenario is just any number where:
(n - 50) % 20 %3 != 0 (where 50, 20, and 3 are constants from QuizSession/constants.js). 
Hilariously, it's also immediately reached if you set INITIAL_QUEUE_LIMIT to 1.
