### PR TITLE
Mark isFinal when wrap up is ready, regardless of queue size

### DIFF
--- a/app/features/quiz/QuizSession/QuizAnswer/logic.js
+++ b/app/features/quiz/QuizSession/QuizAnswer/logic.js
@@ -53,7 +53,7 @@ export const submitAnswerLogic = createLogic({
       quiz.answer.update({
         value: answerValue,
         type: isKana(answerValue) ? ANSWER_TYPES.READING : ANSWER_TYPES.WORD,
-      })
+      }),
     );
 
     if (!isValid) {
@@ -114,7 +114,7 @@ export const checkAnswerLogic = createLogic({
           ...updatedAnswer,
           value: matchedAnswer,
           isCorrect: true,
-        })
+        }),
       );
       dispatch(quiz.answer.correct());
       const isOpen = settings.autoExpandAnswerOnSuccess && settings.autoAdvanceOnSuccessDelayMilliseconds > 0;
@@ -124,7 +124,7 @@ export const checkAnswerLogic = createLogic({
           isDisabled: false,
           detailLevel: settings.infoDetailLevelOnSuccess,
           isOpen,
-        })
+        }),
       );
     }
 
@@ -138,7 +138,7 @@ export const checkAnswerLogic = createLogic({
           isDisabled: false,
           detailLevel,
           isOpen,
-        })
+        }),
       );
     }
 
@@ -182,14 +182,7 @@ export const correctAnswerLogic = createLogic({
 export const incorrectAnswerLogic = createLogic({
   type: quiz.answer.incorrect,
   latest: true,
-  process(
-    {
-      getState,
-      action: { payload = {} },
-    },
-    dispatch,
-    done
-  ) {
+  process({ getState, action: { payload = {} } }, dispatch, done) {
     const current = selectCurrent(getState());
     const isLessonQuiz = selectIsLessonQuiz(getState());
     const previouslyIncorrect = selectCurrentPreviouslyIncorrect(getState());
@@ -262,7 +255,7 @@ export const disableReviewLogic = createLogic({
       },
     },
     dispatch,
-    done
+    done,
   ) {
     stopAutoAdvance();
     const isFinalQuestion = selectIsFinalQuestion(getState());
@@ -298,7 +291,6 @@ export const recordAnswerLogic = createLogic({
     const current = selectCurrent(getState());
     const wrapUp = selectWrapUp(getState());
     const isLessonQuiz = selectIsLessonQuiz(getState());
-    const isFinalQuestion = selectIsFinalQuestion(getState());
     const { isCorrect } = selectAnswer(getState());
     const previouslyIncorrect = selectCurrentPreviouslyIncorrect(getState());
     stopAutoAdvance();
@@ -315,6 +307,7 @@ export const recordAnswerLogic = createLogic({
       if (wrapUp.active) {
         dispatch(quiz.session.wrapUp.decrement());
       }
+      const isFinalQuestion = selectIsFinalQuestion(getState());
       if (isFinalQuestion) {
         dispatch(quiz.session.queue.clear());
         setTimeout(() => history.push(`/${category}`), 1000);
@@ -342,7 +335,7 @@ export const recordAnswerLogic = createLogic({
             content:
               'You have several answer submissions still pending. You might be experiencing connection problems.',
             duration: 8000,
-          })
+          }),
         );
       }
 
@@ -382,7 +375,7 @@ export const recordAnswerLogic = createLogic({
               previouslyIncorrect,
               wasAlreadyPending,
               pendingAnswers: [...pendingAnswers],
-            })
+            }),
           );
           dispatch(quiz.answer.record.failure(err));
           done();

--- a/app/features/quiz/QuizSession/QuizAnswer/logic.js
+++ b/app/features/quiz/QuizSession/QuizAnswer/logic.js
@@ -291,6 +291,7 @@ export const recordAnswerLogic = createLogic({
     const current = selectCurrent(getState());
     const wrapUp = selectWrapUp(getState());
     const isLessonQuiz = selectIsLessonQuiz(getState());
+    const isFinalQuestion = selectIsFinalQuestion(getState());
     const { isCorrect } = selectAnswer(getState());
     const previouslyIncorrect = selectCurrentPreviouslyIncorrect(getState());
     stopAutoAdvance();
@@ -307,7 +308,6 @@ export const recordAnswerLogic = createLogic({
       if (wrapUp.active) {
         dispatch(quiz.session.wrapUp.decrement());
       }
-      const isFinalQuestion = selectIsFinalQuestion(getState());
       if (isFinalQuestion) {
         dispatch(quiz.session.queue.clear());
         setTimeout(() => history.push(`/${category}`), 1000);

--- a/app/features/quiz/QuizSession/logic.js
+++ b/app/features/quiz/QuizSession/logic.js
@@ -33,9 +33,8 @@ export const queueLoadLogic = createLogic({
       const limit = !queueCount
         ? INITIAL_QUEUE_LIMIT
         : wrapUp.active
-          ? wrapUp.count - queueCount
+          ? wrapUp.count
           : Math.min(remainingCount, SUBSEQUENT_QUEUE_LIMIT);
-
       allow({ ...action, payload: { category, limit, currentId } });
     } else {
       reject();

--- a/app/features/quiz/QuizSession/reducer.js
+++ b/app/features/quiz/QuizSession/reducer.js
@@ -43,8 +43,7 @@ const toggleWrapUp = (state) => {
 
   if (active) {
     queue = getWrapUpItems(state);
-    // wrapUp count should be 1 less than queue length
-    count = queue.length - 1;
+    count = queue.length;
   }
 
   return update(state, {

--- a/app/features/quiz/QuizSession/reducer.js
+++ b/app/features/quiz/QuizSession/reducer.js
@@ -27,10 +27,10 @@ const setSynonymModalOpen = (state, { payload }) => update(state, {
 
 export const getWrapUpItems = (state) => {
   let needsReview = difference(state.incorrect, state.complete);
-  if (needsReview.length < 10) {
+  if (needsReview.length < WRAP_UP_STARTING_COUNT) {
     needsReview = [...needsReview, ...difference(state.queue, needsReview)].slice(
       0,
-      WRAP_UP_STARTING_COUNT
+      WRAP_UP_STARTING_COUNT,
     );
   }
   return needsReview;
@@ -43,7 +43,8 @@ const toggleWrapUp = (state) => {
 
   if (active) {
     queue = getWrapUpItems(state);
-    count = queue.length;
+    // wrapUp count should be 1 less than queue length
+    count = queue.length - 1;
   }
 
   return update(state, {
@@ -123,7 +124,7 @@ export const quizSessionReducer = handleActions(
     [quiz.session.addComplete]: addIdToComplete,
     [quiz.session.reset]: (state) => ({ ...initialQuizSessionState, category: state.category }),
   },
-  initialQuizSessionState
+  initialQuizSessionState,
 );
 
 export default quizSessionReducer;

--- a/app/features/quiz/QuizSession/selectors.js
+++ b/app/features/quiz/QuizSession/selectors.js
@@ -90,7 +90,7 @@ export const selectIsFinalQuestion = createSelector(
   [selectSessionRemainingCount, selectWrapUp, selectQueue, selectCurrentId],
   (remainingCount, wrapUp, queue, currentId) => {
     const isLastInQueue = queue.length > 0 && currentId === queue[0];
-    const shouldWrapUp = wrapUp.active && wrapUp.count === 0;
+    const shouldWrapUp = wrapUp.active && wrapUp.count === 1;
     return shouldWrapUp || (remainingCount === 1 && isLastInQueue);
   },
 );

--- a/app/features/quiz/QuizSession/selectors.js
+++ b/app/features/quiz/QuizSession/selectors.js
@@ -91,7 +91,7 @@ export const selectIsFinalQuestion = createSelector(
   (remainingCount, wrapUp, queue, currentId) => {
     const isLastInQueue = queue.length > 0 && currentId === queue[0];
     const shouldWrapUp = wrapUp.active && wrapUp.count === 0;
-    return (remainingCount === 1 || shouldWrapUp) && isLastInQueue;
+    return shouldWrapUp || (remainingCount === 1 && isLastInQueue);
   },
 );
 


### PR DESCRIPTION
## Overview

This PR addresses a bug introduced in #108 with ending a QuizSession when wrap-up is enabled. This was due to an incorrect assumption that the wrapUp count and queue size remain in lock-step (where queue length == wrapUp.count + 1); this is generally true but seems to be violated when activating wrapUp with queue size < wrapUp start size (10). The wrapUp count needs to be kept consistent w.r.t the queue size so we can be sure to always have enough reviews to complete the wrapUp, as the queue is emptying.

The queue size should have no bearing on whether the session is over, if the user is wrapped up. So the logic of isFinalQuestion was rearranged to return `true` if the wrapUp count is 0, regardless of queue size.

## Risks
There's a chance that further inter-related logic interacts with this behavior in a way I'm not familiar with. I've tried testing all the different scenarios of ending a session that I could think of.
