### PR TITLE
Level 0 reset

### DIFF
--- a/app/features/dashboard/__tests__/__snapshots__/getReviewStatusText.test.js.snap
+++ b/app/features/dashboard/__tests__/__snapshots__/getReviewStatusText.test.js.snap
@@ -20,7 +20,7 @@ exports[`getReviewStatusText() on vacation 1`] = `
   On Vacation:
    
   <styled.span>
-    since
+    since 
     Dec 26th 2017
   </styled.span>
 </Styled(styled.h3)>

--- a/app/features/settings/AccountForm.js
+++ b/app/features/settings/AccountForm.js
@@ -23,31 +23,36 @@ import RangeField from './RangeField';
 
 import { Form, Section, SubSection, Block, ApiLink, Controls } from './styles';
 
-const ResetProgress = ({ currentLevel, handleSubmit, submitting, submitSucceeded }) => (
-  <Form onSubmit={handleSubmit}>
-    <Block>
-      <Field
-        name="resetLevel"
-        label="Reset to start of level:"
-        component={RangeField}
-        min={1}
-        max={currentLevel}
-        step={1}
-      />
-      <Field
-        name="confirmation"
-        label="Enter username to confirm:"
-        placeholder="名前"
-        component={InputField}
-      />
-    </Block>
-    <Controls>
-      <Button type="submit">
-        {(submitting && 'Submitting') || (submitSucceeded && 'Reset!') || 'Reset Progress'}
-      </Button>
-    </Controls>
-  </Form>
-);
+const ResetProgress = ({ currentLevel, handleSubmit, submitting, submitSucceeded }) => {
+  const tip = 'This action will reset all unlocked Vocab from higher levels; e.g. resetting to 19 resets Vocab from Levels 20 and up';
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Block>
+        <Field
+          name="resetLevel"
+          label="Reset to level:"
+          component={RangeField}
+          note={tip}
+          min={0}
+          max={currentLevel}
+          step={1}
+        />
+        <Field
+          name="confirmation"
+          label="Enter username to confirm:"
+          placeholder="名前"
+          component={InputField}
+        />
+      </Block>
+      <Controls>
+        <Button type="submit">
+          {(submitting && 'Submitting') || (submitSucceeded && 'Reset!') || 'Reset Progress'}
+        </Button>
+      </Controls>
+    </Form>
+  );
+};
 
 ResetProgress.propTypes = {
   ...formPropTypes,
@@ -58,7 +63,7 @@ const ResetProgressForm = compose(
   connect((state) => ({
     name: selectUsername(state),
     currentLevel: selectUserLevel(state),
-    initialValues: { resetLevel: 1 },
+    initialValues: { resetLevel: 0 },
   })),
   reduxForm({
     form: 'resetProgress',


### PR DESCRIPTION
## Overview
This change changes the user reset request options to include 0 and adds a note explaining the exact behavior. The reset behavior now resets the user's levels and reviews TO the specified level, rather than including the requested level in those being reset. This allows for slightly clearer wording if the behavior, maybe avoiding resets of a level users don't expect.

## Testing
This was tested locally - resets to level e.g. 4 do not reset open reviews or levels for Vocab of level 4, but are when reset to level 3. The front-end input range now extends from 0-60, and all other functionality is unchanged.

A corresponding PR for the back-end changes is [here](https://github.com/Kaniwani/kw-backend/pull/484)

## KaniWani

- [ ] You have followed our [**contributing guidelines**](https://github.com/Kaniwani/kw-frontend/blob/master/.github/CONTRIBUTING.md)
- [ ] Double-check your branch is based on `master` and targets `master`
- [ ] Pull request has unit tests (as relevant - visual updates can be manually checked instead)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Description explains the issue/use-case resolved
