### PR TITLE
Add a white background to search input

### DIFF
--- a/app/common/styles/global.js
+++ b/app/common/styles/global.js
@@ -63,6 +63,10 @@ const GlobalStyle = createGlobalStyle`
     outline: .15rem solid;
     outline-offset: .15rem;
   }
+  /* force search inputs of search type to have white background (Safari iOS) */
+  input[type="search"] {
+    background-color: white;
+  }
 
   h1, h2, h3, h4, h5, h6 {
     font-family: ${ffHeading};


### PR DESCRIPTION
Related issue: https://kaniwani.slack.com/archives/C03BJ331F/p1632234367010000

This pull request is about fixing a grey background on search[input] fields on iOS Safari.

It was a bit tricky to test it because of port forwarding + CORS + Safari on iOS but I managed to do it.

![IMG_00E9D5C3E8CD-1](https://user-images.githubusercontent.com/293337/138064491-4f2fb97c-84c7-43cb-9e92-fb208a71e7c9.jpeg)

cc @DJTB 