### PR TITLE
Use flex instead of padding for the landing submit button

### DIFF
--- a/app/features/landing/styles.js
+++ b/app/features/landing/styles.js
@@ -195,7 +195,9 @@ export const SubmitButton = styled.button`
   ${resetButton}
   ${gamma}
   margin: .5rem 0;
-  padding: .2rem .3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 12rem;
   height: 2.5rem;
   border-radius: 10px;


### PR DESCRIPTION
The padding is wrong for the submit button on the landing/login page (on Firefox).
This is because of using a responsively scaled font size + using a hardcoded padding value.

To fix this issue, it is better to use `flex` to rely on aligning the button text.

<img width="474" alt="Screen Shot 2022-02-10 at 10 39 30 AM" src="https://user-images.githubusercontent.com/293337/153380120-f3c50e36-11ee-4022-9e58-93a61164ddac.png">

Tested on: Firefox, Google Chrome, and Safari Desktop.