### PR TITLE
Feature: answer length hint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -86,6 +86,8 @@
     "react/jsx-one-expression-per-line": 0,
     "react/require-extension": 0,
     "react/require-default-props": 1,
+    "react/state-in-constructor": 1,
+    "react/static-property-placement": 1,
     "react/self-closing-comp": 0,
     "require-yield": 0,
     "valid-jsdoc": 1

--- a/app/features/quiz/QuizSession/QuizQuestion/index.js
+++ b/app/features/quiz/QuizSession/QuizQuestion/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { getMoraCount } from 'hatsuon';
 
 import { selectCurrent, selectIsLessonQuiz } from 'features/quiz/QuizSession/selectors';
 import { selectAnswer } from 'features/quiz/QuizSession/QuizAnswer/selectors';
@@ -9,19 +10,21 @@ import {
   selectSecondaryMeanings,
   selectPrimaryVocabId,
 } from 'features/reviews/selectors';
-import { selectTags } from 'features/vocab/selectors';
+import { selectTags, selectPrimaryReading } from 'features/vocab/selectors';
 
+import A from 'common/components/A';
 import { TagsList } from 'common/components/TagsList';
 import Question from './Question';
 import Flyover from './Flyover';
 
-import { Wrapper } from './styles';
+import { Wrapper, Footer, MoraCount, MoraCountSpacer } from './styles';
 
 export class QuizQuestion extends React.Component {
   static propTypes = {
     primaryMeaning: PropTypes.string,
     secondaryMeanings: PropTypes.array,
     tags: PropTypes.array,
+    moraCount: PropTypes.number,
     streak: PropTypes.number,
     isLessonQuiz: PropTypes.bool,
     isIgnored: PropTypes.bool,
@@ -34,6 +37,7 @@ export class QuizQuestion extends React.Component {
     primaryMeaning: '',
     secondaryMeanings: [],
     tags: [],
+    moraCount: 0,
     streak: null,
     isLessonQuiz: false,
     isIgnored: false,
@@ -64,6 +68,7 @@ export class QuizQuestion extends React.Component {
       primaryMeaning,
       secondaryMeanings,
       tags,
+      moraCount,
       isLessonQuiz,
       isDisabled,
       isIgnored,
@@ -72,9 +77,25 @@ export class QuizQuestion extends React.Component {
     return (
       <Wrapper>
         <Question primaryMeaning={primaryMeaning} secondaryMeanings={secondaryMeanings} />
-        <TagsList tags={tags} isVisible={!isDisabled} />
-        {!isLessonQuiz &&
-          isDisabled && <Flyover isIgnored={isIgnored} from={initialStreak} to={streak} />}
+        <Footer>
+          {moraCount > 0 && (
+            <A
+              plainLink
+              external
+              href="https://en.wikipedia.org/wiki/On_(Japanese_prosody)#Examples"
+            >
+              <MoraCount lang="ja" title="Answer contains this many 音 (おん)">
+                {moraCount}音
+              </MoraCount>
+            </A>
+          )}
+          <TagsList tags={tags} isVisible={!isDisabled} />
+          {/* ensures TagsList is properly centered */}
+          {moraCount > 0 && <MoraCountSpacer>{moraCount}音</MoraCountSpacer>}
+        </Footer>
+        {!isLessonQuiz && isDisabled && (
+          <Flyover isIgnored={isIgnored} from={initialStreak} to={streak} />
+        )}
       </Wrapper>
     );
   }
@@ -83,6 +104,8 @@ export class QuizQuestion extends React.Component {
 const mapStateToProps = (state, props) => {
   const { id: reviewId, streak } = selectCurrent(state, props);
   const primaryVocabId = selectPrimaryVocabId(state, { id: reviewId });
+  const reading = selectPrimaryReading(state, { id: primaryVocabId });
+  const moraCount = getMoraCount(reading);
   const tags = selectTags(state, { id: primaryVocabId });
   const primaryMeaning = selectPrimaryMeaning(state, { id: reviewId });
   const secondaryMeanings = selectSecondaryMeanings(state, { id: reviewId });
@@ -92,6 +115,7 @@ const mapStateToProps = (state, props) => {
     primaryMeaning,
     secondaryMeanings,
     tags,
+    moraCount,
     streak,
     isLessonQuiz,
     ...selectAnswer(state, props),

--- a/app/features/quiz/QuizSession/QuizQuestion/styles.js
+++ b/app/features/quiz/QuizSession/QuizQuestion/styles.js
@@ -2,7 +2,8 @@ import styled, { css } from 'styled-components';
 
 import { white } from 'common/styles/colors';
 import { gutter, centerByMargin } from 'common/styles/layout';
-import { giga, gamma } from 'common/styles/typography';
+import { ghost } from 'common/styles/utils';
+import { giga, gamma, delta } from 'common/styles/typography';
 import { borderRadius } from 'common/styles/sizing';
 import { srsRankUp, srsRankDown } from 'common/styles/animation';
 import { outerLight } from 'common/styles/shadows';
@@ -42,6 +43,22 @@ export const Wrapper = styled.div`
   justify-content: space-between;
   text-align: center;
   flex: 1 1 100%;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+`;
+
+export const MoraCount = styled.div`
+  ${delta}
+  padding: .25rem .4rem;
+  font-weight: 500;
+`;
+
+export const MoraCountSpacer = styled(MoraCount)`
+  ${ghost}
 `;
 
 export const FlyoverWrapper = styled.div`

--- a/app/features/quiz/QuizSession/index.js
+++ b/app/features/quiz/QuizSession/index.js
@@ -9,6 +9,10 @@ import { selectInfoOpen } from 'features/quiz/QuizSession/QuizInfo/selectors';
 import { selectIsLessonQuiz } from 'features/quiz/QuizSession/selectors';
 import { selectAnswerDisabled } from 'features/quiz/QuizSession/QuizAnswer/selectors';
 import { stopAutoAdvance } from 'features/quiz/QuizSession/QuizAnswer/logic';
+import AddSynonymModal from 'features/quiz/QuizSession/QuizInfo/AddSynonymModal';
+
+import backgroundImage from 'common/assets/img/reviews.svg';
+import { SRS_COLORS } from 'common/styles/colors';
 
 import QuizHeader from './QuizHeader';
 import QuizAnswer from './QuizAnswer';
@@ -16,11 +20,7 @@ import QuizQuestion from './QuizQuestion';
 import QuizControls from './QuizControls';
 import QuizInfo from './QuizInfo';
 
-import AddSynonymModal from 'features/quiz/QuizSession/QuizInfo/AddSynonymModal';
-
-import backgroundImage from 'common/assets/img/reviews.svg';
 import { Upper, Lower, Background } from './styles';
-import { SRS_COLORS } from 'common/styles/colors';
 const QuizBackground = pure(Background);
 
 const isInputField = ({ target }) => ['INPUT', 'TEXTAREA'].includes(target.nodeName);

--- a/app/pages/AboutPage/index.js
+++ b/app/pages/AboutPage/index.js
@@ -124,7 +124,10 @@ function AboutPage() {
               Many WK words have very similar meanings. To alleviate this, if you add{' '}
               <strong>meaning synoynms on WK</strong> they will appear as part of the KW meaning /
               quiz question. You can also add <strong>answer synonyms on KW</strong> as acceptable
-              answers during your reviews or on the vocabulary entry page.
+              answers during your reviews or on the vocabulary entry page. The review screen also
+              contains a mora count in the bottom left corner of the question. For example, the
+              question for Girl would display 5 to hint that the answer is (女の子) おんなのこ and
+              not (少女) しょうじょ which only has 3 morae [しょ, う, じょ].
             </P>
           </Container>
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "core-js": "3.26.1",
     "cuid": "2.1.8",
     "date-fns": "^1",
+    "hatsuon": "^2.0.0",
     "immutability-helper": "3.1.1",
     "localforage": "1.10.0",
     "lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6896,6 +6896,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+hatsuon@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/hatsuon/-/hatsuon-2.0.0.tgz#7e072c620eec0c30c6996262735864dd896e11a0"
+  integrity sha512-9PnNR5K/w68DVSNPKJEv6aw0keQi2SQkN26dPrbKDuErCHZyOBTZV9GfmSrWOFarYcL6VoycUTBymyh6VpMjuA==
+
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"


### PR DESCRIPTION
Adds a count to the bottom left of quiz questions hinting to the number of [音 (on)](https://en.wikipedia.org/wiki/On_(Japanese_prosody)) in the answer reading.

![image](https://github.com/Kaniwani/kw-frontend/assets/5353151/6dcc0284-bce5-4360-9dd7-863c6e55ed50)

Fortunately I already created an algorithm for this in another project: [hatsuon](https://github.com/DJTB/hatsuon)

