### PR TITLE
Add "repeat until correct" option

### DIFF
--- a/app/features/quiz/QuizSession/QuizAnswer/logic.js
+++ b/app/features/quiz/QuizSession/QuizAnswer/logic.js
@@ -297,6 +297,7 @@ export const recordAnswerLogic = createLogic({
     const isFinalQuestion = selectIsFinalQuestion(getState());
     const { isCorrect } = selectAnswer(getState());
     const previouslyIncorrect = selectCurrentPreviouslyIncorrect(getState());
+    const { repeatUntilCorrect } = selectUserSettings(getState());
     stopAutoAdvance();
 
     // only add to correct/incorrect totals on first attempt
@@ -316,7 +317,7 @@ export const recordAnswerLogic = createLogic({
         setTimeout(() => history.push(`/${category}`), 1000);
       }
       dispatch(quiz.session.current.replace());
-    } else {
+    } else if (!repeatUntilCorrect) {
       dispatch(quiz.session.current.rotate());
     }
 
@@ -391,7 +392,9 @@ export const autoAdvanceLogic = createLogic({
   type: quiz.question.advance,
   warnTimeout: 11000,
   process({ getState }, dispatch, done) {
-    const { autoAdvanceOnSuccessDelayMilliseconds } = selectUserSettings(getState());
+    const { autoAdvanceOnSuccessDelayMilliseconds, repeatUntilCorrect } = selectUserSettings(
+      getState()
+    );
     const answerIgnored = selectAnswerIgnored(getState());
 
     if (answerIgnored) {
@@ -403,7 +406,9 @@ export const autoAdvanceLogic = createLogic({
       setTimeout(() => {
         dispatch(quiz.answer.reset());
         dispatch(quiz.info.reset());
-        dispatch(quiz.session.current.rotate());
+        if (!repeatUntilCorrect) {
+          dispatch(quiz.session.current.rotate());
+        }
         done();
       }, msDelay);
     } else {

--- a/app/features/settings/SettingsForm.js
+++ b/app/features/settings/SettingsForm.js
@@ -97,6 +97,12 @@ export function SettingsForm({ minWk, maxWk, handleSubmit, submitting, submitSuc
           normalize={infoLevelNameToNum}
           note="Incorrect lessons are always high detail."
         />
+        <Field
+          name="repeatUntilCorrect"
+          label="Repeat item until correct:"
+          component={ToggleField}
+          parse={Boolean}
+        />
         <SubSection>
           <H4>Auto Advance</H4>
           <Field

--- a/app/features/user/selectors.js
+++ b/app/features/user/selectors.js
@@ -40,6 +40,7 @@ export const selectUserSettings = createSelector(
       'autoExpandAnswerOnFailure',
       'infoDetailLevelOnSuccess',
       'infoDetailLevelOnFailure',
+      'repeatUntilCorrect',
       'autoAdvanceOnSuccess',
       'autoAdvanceOnSuccessDelayMilliseconds',
       'followMe',
@@ -75,7 +76,8 @@ export const selectFreshUser = createSelector(
     selectReviewsCount,
     getBy(['entities', 'reviews'], (x = {}) => Object.keys(x).length),
   ],
-  (nextReviewDate, lessonsCount, reviewsCount, reviewEntitiesCount) => !nextReviewDate && lessonsCount && !reviewsCount && !reviewEntitiesCount
+  (nextReviewDate, lessonsCount, reviewsCount, reviewEntitiesCount) =>
+    !nextReviewDate && lessonsCount && !reviewsCount && !reviewEntitiesCount
 );
 
 export const selectLastWkSyncDate = createSelector(


### PR DESCRIPTION
This pull request adds a "Repeat until correct" option to the user settings, which lets users repeat the same review item when they get it wrong or ignore it, until they get it right. The feature is inspired by a setting of [Reorder Omega for WaniKani](https://community.wanikani.com/t/userscript-reorder-omega/56250), which I always use, because it can be annoying when an incorrect/ignored item gets shuffled back in the review queue. It saves time if the user can just try again immediately, especially when it's just a typo that should be ignored.

As the user setting also needs to be stored, I will open a corresponding PR for the backend repo which I will link here.